### PR TITLE
update duplication report specs and legends

### DIFF
--- a/static/projects/reports/duplication.md
+++ b/static/projects/reports/duplication.md
@@ -1,30 +1,42 @@
 ## Duplication Checker
+The following reports identify potential duplication in the {{project}} sequencing efforts.
 
-### [Target Overlaps](/search?query=long_list%3D{{project}}%20AND%20length%28long_list%29%3E1%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csequencing_status_{{lc_project}}%2Csequencing_status%2Clong_list%2Cother_priority%2Cfamily_representative&names=&report=tree&collapseMonotypic=true&treeStyle=rect&treeThreshold=2000&pointSize=15)\*: Overlaps between {{project}} and EBP projects
+> **Click on report title** to retrieve the corresponding species list and additional information.
 
-:::grid{container direction="row" spacing="1" .padded}
-::include{pageId=/projects/reports/duplication/report0.md project={{project}} bioproject={{bioproject}} size=4 .unpadded}
-::include{pageId=/projects/reports/duplication/list0.md project={{project}} bioproject={{bioproject}} size=8 .unpadded}
-:::
+### [Already Sequenced](/search?query=long_list%3D{{project}}%20AND%20ebp_standard_date%20AND%20bioproject%21%3D{{bioproject}}%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csequencing_status_{{lc_project}}&report=arc&cat=sequencing_status_{{lc_project}}&y=long_list%3D{{project}}&rank=species&names=&ranks=&sortBy=sequencing_status_{{lc_project}}&sortOrder=desc&xOpts=%3B%3B1%3B%3B): assemblies meeting EBP standards exist
 
-### [Already Sequenced](/search?query=long_list%3D{{project}}%20AND%20bioproject%3D%21{{bioproject}}%20AND%20tax_rank%28species%29%20AND%20ebp_metric_date&result=taxon&includeEstimates=true&&taxonomy=ncbi&size=10&fields=assembly_level%2Cassembly_span%2Cbioproject%2Csequencing_status%2Csequencing_status_{{lc_project}}%2Clong_list&report=tree&cat=sequencing_status_{{lc_project}}&collapseMonotypic=true&treeStyle=rect&treeThreshold=2000&pointSize=15)\*: assemblies available meet {{project}} standards
 
 :::grid{container direction="row" spacing="1" .padded}
 ::include{pageId=/projects/reports/duplication/report1.md project={{project}} bioproject={{bioproject}} size=4 .unpadded}
 ::include{pageId=/projects/reports/duplication/list1.md project={{project}} bioproject={{bioproject}} size=8 .unpadded}
+
+
 :::
 
-### [In progress by other EBP affiliate](/search?query=long_list%3D{{project}}%20AND%20length%28long_list%29%3E1%20AND%20sequencing_status%3E%3Dsample_collected%20AND%20sequencing_status_{{lc_project}}%3Dnull%20AND%20bioproject%3D%21{{bioproject}}%2Cnull%20AND%20ebp_metric_date%3Dnull%20AND%20assembly_level%3Dnull%2C%21chromosome%2C%21complete%20genome%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Cbioproject%2Csample_collected%2Csample_acquired%2Cin_progress%2Copen%2Cinsdc_open%2Csequencing_status%2Csequencing_status_{{lc_project}}%2Clong_list&report=arc&cat=sequencing_status_{{lc_project}}&collapseMonotypic=true&treeStyle=rect&treeThreshold=2000&pointSize=15&y=long_list%3D{{project}}&rank=species): not started by {{project}}
+### [Active duplication detected](/search?query=length%28sample_collected%29%3E1%20AND%20sequencing_status_{{lc_project}}%3E%3Dsample_collected%20AND%20bioproject%3Dnull%2C%21{{bioproject}}%20AND%20ebp_standard_date%3Dnull%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csample_collected%2Csequencing_status_{{lc_project}}%2Csequencing_status_%2A&report=arc&cat=sequencing_status_{{lc_project}}&y=sequencing_status_{{lc_project}}%3E%3Dsample_collected&rank=species&names=&ranks=&sortBy=sequencing_status_{{lc_project}}&sortOrder=desc&xOpts=%3B%3B1%3B%3B): efforts initiated by {{project}} and at least one other project
 
-:::grid{container direction="row" spacing="1" .padded}
-::include{pageId=/projects/reports/duplication/report2.md project={{project}} bioproject={{bioproject}} size=4 .unpadded}
-::include{pageId=/projects/reports/duplication/list2.md project={{project}} bioproject={{bioproject}} size=8 .unpadded}
-:::
-
-### [In progress by {{project}} and others](/search?query=length%28sample_collected%29%3E1%20AND%20sequencing_status_{{lc_project}}%3E%3Dsample_collected%20AND%20bioproject%3Dnull%2C%21{{bioproject}}%20AND%20ebp_metric_date%3Dnull%20AND%20assembly_level%3Dnull%2C%21chromosome%2C%21complete%20genome%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csample_collected%2Csample_acquired%2Cin_progress%2Copen%2Cinsdc_open%2Csequencing_status%2Csequencing_status_{{lc_project}}&report=arc&cat=sequencing_status_{{lc_project}}&collapseMonotypic=true&treeStyle=rect&treeThreshold=2000&pointSize=15&y=sequencing_status_{{lc_project}}%3E%3Dsample_acquired&rank=species): need overlap solving
 
 :::grid{container direction="row" spacing="1" .padded}
 ::include{pageId=/projects/reports/duplication/report3.md project={{project}} bioproject={{bioproject}} size=4 .unpadded}
 ::include{pageId=/projects/reports/duplication/list3.md project={{project}} bioproject={{bioproject}} size=8 .unpadded}
+
+
+:::
+
+### [In progress by at least one other project](/search?query=long_list%3D{{project}}%20AND%20sequencing_status_{{lc_project}}%3Dnull%20AND%20length%28sample_collected%29%3E%3D1%20AND%20bioproject%3D%21{{bioproject}}%2Cnull%20AND%20ebp_standard_date%3Dnull%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csample_collected%2Csequencing_status_{{lc_project}}%2Csequencing_status_%2A&report=arc&cat=sequencing_status_{{lc_project}}&y=long_list%3D{{project}}&rank=species): not started by {{project}}
+
+:::grid{container direction="row" spacing="1" .padded}
+::include{pageId=/projects/reports/duplication/report2.md project={{project}} bioproject={{bioproject}} size=4 .unpadded}
+::include{pageId=/projects/reports/duplication/list2.md project={{project}} bioproject={{bioproject}} size=8 .unpadded}
+
+:::
+
+
+
+### [Target List Overlaps](/search?query=long_list%3D{{project}}%20AND%20length%28long_list%29%3E1%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csequencing_status_{{lc_project}}%2Clong_list%2Cother_priority%2Cfamily_representative&names=&report=table)\*: Overlaps in the scope of {{project}} and other projects in GoaT
+
+:::grid{container direction="row" spacing="1" .padded}
+::include{pageId=/projects/reports/duplication/report0.md project={{project}} bioproject={{bioproject}} size=4 .unpadded}
+::include{pageId=/projects/reports/duplication/list0.md project={{project}} bioproject={{bioproject}} size=8 .unpadded}
 
 :::

--- a/static/projects/reports/duplication/list0.md
+++ b/static/projects/reports/duplication/list0.md
@@ -6,6 +6,15 @@
 - target species of {{project}}
 - present in any other declared target list (long_list)
 
-<!-- ::grid{direction="row" spacing="2" class="padded"} -->
+::grid{direction="row" spacing="2" class="padded"}
 
-(\*) Click on link for summary table and tree report.
+**EBP suggestion:** these highlight similarities in project scope. Consider contacting other projects to initiate collaborations before efforts initiate
+
+
+::grid{direction="row" spacing="3" class="padded"}
+
+::grid{direction="row" spacing="3" class="padded"}
+
+_(\*) Overlaps in project scope. Species in {{project}}'s target list also in the list of potential targets of other projects, out of all species in {{project}} wishlist._
+
+

--- a/static/projects/reports/duplication/list1.md
+++ b/static/projects/reports/duplication/list1.md
@@ -2,12 +2,15 @@
 
 - target species of {{project}}
 - assembly not submitted by {{project}}
-- contig n50 > 1Mb
-- scaffold n50 > 10Mb
-- has chromosome-level assembly
+- assembly meeting [EBP standard criteria](https://github.com/genomehubs/goat-data/wiki/5-Earth-Biogenome-Project-(EBP)-FAQs#how-are-ebp-standard-criteria-and-dates-calculated) is available for species
+- For _status per project_ use [this link](/search?query=long_list%3D{{project}}%20AND%20ebp_standard_date%20AND%20bioproject%21%3D{{bioproject}}%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=10&fields=assembly_level%2Csequencing_status_{{lc_project}}%2Csequencing_status_%2A&emptyColumns=false)
 
-<!-- ::grid{direction="row" spacing="2" class="padded"} -->
+::grid{direction="row" spacing="2" class="padded"}
 
-(\*) Click on link for summary table and tree report.
+**EBP suggestion:** revisit the need to sequence these species.
 
-For **status per project** use [this link](/search?query=long_list%3D{{project}}%20AND%20bioproject%3D%21{{bioproject}}%20AND%20tax_rank%28species%29%20AND%20ebp_metric_date&result=taxon&includeEstimates=true&taxonomy=ncbi&size=25&fields=insdc_open%2Csequencing_status_%2A%2Csequencing_status)
+
+::grid{direction="row" spacing="3" class="padded"}
+
+_(\*) Species that have at least one assembly available in INSDC meeting the EBP-standard criteria, out of all species from {{project}}'s target list._
+

--- a/static/projects/reports/duplication/list2.md
+++ b/static/projects/reports/duplication/list2.md
@@ -1,10 +1,16 @@
 ### Criteria applied for search:
 
 - target species of {{project}} and at least one other project
-- sample collected or further in the pipeline of an EBP affiliate
+- sample collected or further in the pipeline of another project on GoaT
 - sample not yet collected by {{project}}
-- an assembly meeting {{project}}/EBP standards has not been published
+- an assembly meeting EBP standards has not been published
 
-<!-- ::grid{direction="row" spacing="2" class="padded"} -->
+::grid{direction="row" spacing="2" class="padded"}
 
-For **status per project** use [this link](/search?query=long_list%3D{{project}}%20AND%20length%28long_list%29%3E1%20AND%20sequencing_status%3E%3Dsample_collected%20AND%20sequencing_status_{{lc_project}}%3Dnull%20AND%20bioproject%3D%21{{bioproject}}%2Cnull%20AND%20ebp_metric_date%3Dnull%20AND%20assembly_level%3Dnull%2C%21chromosome%2C%21complete%20genome%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&size=25&fields=assembly_level%2Cbioproject%2Cinsdc_open%2Csequencing_status_%2A%2Csequencing_status%2Clong_list&names=&report=arc&cat=sequencing_status_{{lc_project}}&collapseMonotypic=true&treeStyle=rect&treeThreshold=2000&pointSize=15&y=long_list%3D{{project}}&rank=species)
+
+**EBP suggestion:** consider contacting other projects to coordinate sequencing efforts.
+
+::grid{direction="row" spacing="3" class="padded"}
+
+_(*) Species being actively worked on by another project in GoaT but not started by {{project}},  out of all species from {{project}}'s target list._
+

--- a/static/projects/reports/duplication/list3.md
+++ b/static/projects/reports/duplication/list3.md
@@ -1,12 +1,15 @@
 ### Criteria applied for search:
 
-- sample in progress by {{project}} AND at least one other project (in the EBP Network)
-- an assembly meeting {{project}}/EBP standards has not been published
+- species is collected or further in the {{project}}'s sequencing pipeline, but not yet submitted
+- species has been at least collected by one or more additional projects in GoaT
+- an assembly meeting [EBP standard criteria](https://github.com/genomehubs/goat-data/wiki/5-Earth-Biogenome-Project-(EBP)-FAQs#how-are-ebp-standard-criteria-and-dates-calculated) has not been published
+- an assembly might exist in INSDC, but does not meet EBP standard criteria
 
-<!-- ::grid{direction="row" spacing="1" class="padded"} -->
+::grid{direction="row" spacing="2" class="padded"}
 
-For **status per project** use [this link](/search?query=length%28sample_collected%29%3E1%20AND%20sequencing_status_{{lc_project}}%3E%3Dsample_collected%20AND%20bioproject%3Dnull%2C%21{{bioproject}}%20AND%20ebp_metric_date%3Dnull%20AND%20assembly_level%3Dnull%2C%21chromosome%2C%21complete%20genome%20AND%20tax_rank%28species%29&result=taxon&includeEstimates=true&taxonomy=ncbi&fields=sequencing_status_%2A%2Csequencing_status)
+**EBP suggestion:** consider coordination with identified [project representatives](/projects) to avoid duplication or to improve existing assemblies.
 
-<!-- ::grid{direction="row" spacing="2" class="padded"} -->
+::grid{direction="row" spacing="2" class="padded"}
 
-(\*) Species initiated in {{project}} pipeline and at least 1 EBP affiliate out of all species onboarded by {{project}}.
+
+_(\*) Species initiated in {{project}} pipeline and at least 1 other project, out of all {{project}}'s species that reached or passed the "collected" milestone._ 

--- a/static/projects/reports/duplication/report0.md
+++ b/static/projects/reports/duplication/report0.md
@@ -6,5 +6,5 @@ rank: species
 includeEstimates: true
 result: taxon
 taxonomy: ncbi
-caption: "**Target-species with overlaps**"
+caption: "**Shared potential target species**(*)"
 ```

--- a/static/projects/reports/duplication/report1.md
+++ b/static/projects/reports/duplication/report1.md
@@ -1,10 +1,10 @@
 ```report
 report: arc
-x: "long_list={{project}} AND ebp_metric_date AND bioproject!={{bioproject}}"
+x: "long_list={{project}} AND ebp_standard_date AND bioproject!={{bioproject}}"
 y: "long_list={{project}}"
 rank: species
 includeEstimates: true
 result: taxon
 taxonomy: ncbi
-caption: "**Already Sequenced**"
+caption: "{{project}} targets already sequenced by others(*)"
 ```

--- a/static/projects/reports/duplication/report2.md
+++ b/static/projects/reports/duplication/report2.md
@@ -1,10 +1,10 @@
 ```report
 report: arc
-x: "long_list={{project}} AND length(long_list)>1 AND sequencing_status>=sample_collected AND sequencing_status_{{lc_project}}=null AND bioproject=!{{bioproject}},null AND ebp_metric_date=null AND assembly_level=null,!chromosome,!complete genome"
+x: "long_list={{project}} AND sequencing_status_{{lc_project}}=null AND length(sample_collected)>=1 AND bioproject=!{{bioproject}},null AND ebp_standard_date=null"
 y: "long_list={{project}}"
 rank: species
 includeEstimates: true
 result: taxon
 taxonomy: ncbi
-caption: "**In progress by other EBP affiliate**"
+caption: "**In progress by other EBP affiliate**(*)"
 ```

--- a/static/projects/reports/duplication/report3.md
+++ b/static/projects/reports/duplication/report3.md
@@ -1,10 +1,10 @@
 ```report
 report: arc
-x: "length(sample_collected)>1 AND sequencing_status_{{lc_project}}>=sample_collected AND bioproject=null,!{{bioproject}} AND ebp_metric_date=null AND assembly_level=null,!chromosome,!complete genome"
-y: "sequencing_status_{{lc_project}}>=sample_acquired"
+x: "sequencing_status_{{lc_project}}>=sample_collected AND length(sample_collected)>1 AND bioproject=null,!{{bioproject}} AND ebp_standard_date=null"
+y: "sequencing_status_{{lc_project}}>=sample_collected"
 rank: species
 includeEstimates: true
 result: taxon
 taxonomy: ncbi
-caption: "**In progress by {{project}} and others**(*)"
+caption: "**Initiated by {{project}} and others**(*)"
 ```


### PR DESCRIPTION
This closes [#92](https://github.com/genomehubs/goat-ui/issues/92) 

Updates the duplication reports to match data sent by the auto-emails from EBP:
- the order of reports have changed to reflect types of flags raised (real > potential duplication > shared scope)
- `ebp_standard_date` replaces `ebp_metric_date`
- remove `long_list` when not necessary
- remove `assembly_type` from queries
- remove unnecessary milestones from columns displayed
- revised fields to display in each query
- removed separate link leading to "status per project"
- checked projects missing the checker: absent only for major umbrellas (e.g. EBP, ERGA, Bioplatforms - no target list) and projects missing a Bioproject ID (1KFG,CNGB,GAGA,OGG,PGP and PRGP).

- fields include `sequencing_status_*` (using wildcard to reveal status per project with identified duplication)

@rjchallis  During this update, I noticed the wildcard above has stopped working. Should I raise this in a separate issue or was this deprecated? depending on the answer, I can manually add the fields for all projects in the links.